### PR TITLE
Fix CMake install step: add install targets and preserve RPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,10 @@ endif()
 set(SANE_DEV_BUILD true)
 
 ################################################################################
+# Preserve RPATH in installed binaries so they can find shared libraries.
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+################################################################################
 # Include CMake scripts from cmake directory.
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 

--- a/applications/analysis/CMakeLists.txt
+++ b/applications/analysis/CMakeLists.txt
@@ -10,6 +10,8 @@ if (DCA_BUILD_ANALYSIS)
 
     target_link_libraries(main_analysis PUBLIC signals ${DCA_LIBS} simplex_gm_rule)
 
+  install(TARGETS main_analysis RUNTIME DESTINATION bin)
+
   message("DCA_MODEL_IS_MATERIAL_LATTICE ${DCA_MODEL_IS_MATERIAL_LATTICE}")
   if (DCA_LATTICE STREQUAL "square")
     #new development of exanded q chi_q_omega
@@ -23,6 +25,7 @@ if (DCA_BUILD_ANALYSIS)
 
     target_link_libraries(chi_q_omega PUBLIC signals ${DCA_LIBS} simplex_gm_rule)
 
+    install(TARGETS chi_q_omega RUNTIME DESTINATION bin)
   endif()
 
 endif()

--- a/applications/cluster_solver_check/CMakeLists.txt
+++ b/applications/cluster_solver_check/CMakeLists.txt
@@ -9,4 +9,6 @@ if (DCA_BUILD_CLUSTER_SOLVER_CHECK)
     dca_gpu_runtime_link(cluster_solver_check)
     dca_gpu_blas_link(cluster_solver_check)
   endif()
+
+  install(TARGETS cluster_solver_check RUNTIME DESTINATION bin)
 endif()

--- a/applications/dca/CMakeLists.txt
+++ b/applications/dca/CMakeLists.txt
@@ -9,4 +9,6 @@ if (DCA_BUILD_DCA)
   endif()
   
   target_link_libraries(main_dca PUBLIC FFTW::Double signals ${DCA_LIBS} dca_io)
+
+  install(TARGETS main_dca RUNTIME DESTINATION bin)
 endif()


### PR DESCRIPTION
- Add install(TARGETS ...) for main_dca, main_analysis, chi_q_omega, and cluster_solver_check application binaries
- Set CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE so installed binaries can find shared libraries (OpenBLAS, HDF5, FFTW) without LD_LIBRARY_PATH at runtime

Tested with Ninja generator + spack environment.